### PR TITLE
Update Tailwind peerDependency to allow 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/semencov/tailwindcss-font-inter",
   "peerDependencies": {
-    "tailwindcss": "^2.0.0"
+    "tailwindcss": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "cssjson": "^2.1.3",


### PR DESCRIPTION
It appears this plugin works just fine with v3 of tailwind.  This updates the peer dependency to allow for it.